### PR TITLE
Generate toBuilder() method if dataObjectEnhancement = BUILDER

### DIFF
--- a/src/main/resources/templates/java/DEFINED_OPERATION_RESULT
+++ b/src/main/resources/templates/java/DEFINED_OPERATION_RESULT
@@ -26,6 +26,7 @@ public class ${className}
 		<@classMembers.addBuilderFields className='Builder' fields=selections indent='\t\t'/>
 		<@classMembers.addBuildMethod resultClassName=className fields=selections indent='\t\t'/>
 		<#lt/>	}
+		<@classMembers.addToBuilderMethod builderClassName='Builder' fields=selections indent='\t'/>
 	</#if>
 }
 //CHECKSTYLE:ON

--- a/src/main/resources/templates/java/DYNAMIC_OPERATION_RESULT
+++ b/src/main/resources/templates/java/DYNAMIC_OPERATION_RESULT
@@ -26,6 +26,7 @@ public class ${className}
 		<@classMembers.addBuilderFields className='Builder' fields=selections indent='\t\t'/>
 		<@classMembers.addBuildMethod resultClassName=className fields=selections indent='\t\t'/>
 		<#lt/>	}
+		<@classMembers.addToBuilderMethod builderClassName='Builder' fields=selections indent='\t'/>
 	</#if>
 }
 //CHECKSTYLE:ON

--- a/src/main/resources/templates/java/INPUT_OBJECT
+++ b/src/main/resources/templates/java/INPUT_OBJECT
@@ -28,6 +28,7 @@ implements ${parents?join(", ")}
 		<@classMembers.addBuilderFields className='Builder' fields=fields indent='\t\t'/>
 		<@classMembers.addBuildMethod resultClassName=name fields=fields indent='\t\t'/>
 		<#lt/>	}
+		<@classMembers.addToBuilderMethod builderClassName='Builder' fields=fields indent='\t'/>
 	</#if>
 }
 //CHECKSTYLE:ON

--- a/src/main/resources/templates/java/OBJECT
+++ b/src/main/resources/templates/java/OBJECT
@@ -28,6 +28,7 @@ implements ${parents?join(", ")}
 		<@classMembers.addBuilderFields className='Builder' fields=fields indent='\t\t'/>
 		<@classMembers.addBuildMethod resultClassName=name fields=fields indent='\t\t'/>
 		<#lt/>	}
+		<@classMembers.addToBuilderMethod builderClassName='Builder' fields=fields indent='\t'/>
 	</#if>
 }
 //CHECKSTYLE:ON

--- a/src/main/resources/templates/java/import/classMemberTemplates
+++ b/src/main/resources/templates/java/import/classMemberTemplates
@@ -67,6 +67,16 @@
 	</#list>
 </#macro>
 
+<#macro addToBuilderMethod builderClassName fields indent>
+	<#lt/>${indent}public ${builderClassName} toBuilder() {
+	<#lt/>${indent}	${builderClassName} builder = new ${builderClassName}();
+	<#list fields as field>
+		<#lt/>${indent}	builder.${propertyPrefix!}${getFieldName(field)}${propertySuffix!} = this.${propertyPrefix!}${getFieldName(field)}${propertySuffix!};
+	</#list>
+	<#lt/>${indent}	return builder;
+	<#lt/>${indent}}
+</#macro>
+
 <#macro addBuilderFields className fields indent>
 	<#list fields as field>
 		<@addField field indent/>


### PR DESCRIPTION
Hey!
Motivation for this change on simple example:
Given object of such type:
```
type Coordinate {
    x: Int!
    y: Int!
    z: Int!
}
```
I want to create copy of this object and change just one field, for instance `x`.
Since copy constructor and `toBuilder()` method is not generated by the plugin I have to do smth like this:
``` java
Coordinate.builder().setX(obj.getX() + 1).setY(obj.getY()).setZ(obj.getZ()).build()
```
With `toBuilder()` method it looks more readable:
``` java
obj.toBuilder().setX(obj.getX() + 1).build()
```
Change was successfully tested