### PR TITLE
Generate equals and hashcode methods for defined operations (queries, mutations, and subscriptions)

### DIFF
--- a/src/main/java/com/github/alme/graphql/generator/io/GqlWriter.java
+++ b/src/main/java/com/github/alme/graphql/generator/io/GqlWriter.java
@@ -71,7 +71,6 @@ public class GqlWriter {
 
 	private void setTemplateVariables(GqlConfiguration configuration) throws MojoExecutionException {
 		try {
-			//
 			freemarker.setSharedVariable(SCHEMA_TYPES_PACKAGE_KEY, configuration.getSchemaTypesPackageName());
 			freemarker.setSharedVariable(OPERATIONS_PACKAGE_KEY, configuration.getOperationsPackageName());
 			freemarker.setSharedVariable(DEFINED_OPERATIONS_PACKAGE_KEY, configuration.getDefinedOperationsPackageName());

--- a/src/main/java/com/github/alme/graphql/generator/io/GqlWriter.java
+++ b/src/main/java/com/github/alme/graphql/generator/io/GqlWriter.java
@@ -71,6 +71,7 @@ public class GqlWriter {
 
 	private void setTemplateVariables(GqlConfiguration configuration) throws MojoExecutionException {
 		try {
+			//
 			freemarker.setSharedVariable(SCHEMA_TYPES_PACKAGE_KEY, configuration.getSchemaTypesPackageName());
 			freemarker.setSharedVariable(OPERATIONS_PACKAGE_KEY, configuration.getOperationsPackageName());
 			freemarker.setSharedVariable(DEFINED_OPERATIONS_PACKAGE_KEY, configuration.getDefinedOperationsPackageName());

--- a/src/main/resources/templates/java/DEFINED_OPERATION
+++ b/src/main/resources/templates/java/DEFINED_OPERATION
@@ -41,6 +41,28 @@ public class ${className} implements ${operationsPackage}.${operation?cap_first}
 		return ${currentPackage}.results.${typeName}.class;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof ${className})) return false;
+		${className} other = (${className}) o;
+		java.util.Map<String, Object> otherVariables = other.getVariables();
+		java.util.Map<String, Object> currentVariables = getVariables();
+		if (otherVariables == currentVariables) {
+			return true;
+		}
+		if (otherVariables == null || currentVariables == null) {
+			return false;
+		}
+		return otherVariables.equals(currentVariables);
+	}
+
+	@Override
+	public int hashCode() {
+		return java.util.Objects.hashCode(getVariables());
+	}
+
+
 	<@classMembers.addToString fields=[{'name':'operationName'},{'name':'document'},{'name':'variables'}] indent='\t'/>
 }
 //CHECKSTYLE:ON

--- a/src/main/resources/templates/java/DEFINED_OPERATION
+++ b/src/main/resources/templates/java/DEFINED_OPERATION
@@ -41,28 +41,8 @@ public class ${className} implements ${operationsPackage}.${operation?cap_first}
 		return ${currentPackage}.results.${typeName}.class;
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (!(o instanceof ${className})) return false;
-		${className} other = (${className}) o;
-		java.util.Map<String, Object> otherVariables = other.getVariables();
-		java.util.Map<String, Object> currentVariables = getVariables();
-		if (otherVariables == currentVariables) {
-			return true;
-		}
-		if (otherVariables == null || currentVariables == null) {
-			return false;
-		}
-		return otherVariables.equals(currentVariables);
-	}
-
-	@Override
-	public int hashCode() {
-		return java.util.Objects.hashCode(getVariables());
-	}
-
-
+	<@classMembers.addEquals className=className fields=[{'name':'variables'}] indent='\t'/>
+	<@classMembers.addHashCode fields=[{'name':'variables'}] indent='\t'/>
 	<@classMembers.addToString fields=[{'name':'operationName'},{'name':'document'},{'name':'variables'}] indent='\t'/>
 }
 //CHECKSTYLE:ON

--- a/src/test/java/com/github/alme/graphql/generator/io/GqlWriterTest.java
+++ b/src/test/java/com/github/alme/graphql/generator/io/GqlWriterTest.java
@@ -1,25 +1,20 @@
 package com.github.alme.graphql.generator.io;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-
 import static graphql.language.FieldDefinition.newFieldDefinition;
 import static graphql.language.InputValueDefinition.newInputValueDefinition;
 import static graphql.language.ListType.newListType;
 import static graphql.language.ObjectTypeDefinition.newObjectTypeDefinition;
 import static graphql.language.TypeName.newTypeName;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-
-import com.github.alme.graphql.generator.dto.GqlConfiguration;
-import com.github.alme.graphql.generator.dto.GqlContext;
-import com.github.alme.graphql.generator.io.translator.ObjectTypeTranslator;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -29,22 +24,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.github.alme.graphql.generator.dto.GqlConfiguration;
+import com.github.alme.graphql.generator.dto.GqlContext;
+import com.github.alme.graphql.generator.io.translator.ObjectTypeTranslator;
+import com.github.alme.graphql.generator.io.translator.OperationTranslator;
+
 import graphql.language.Document;
+import graphql.language.Field;
 import graphql.language.ObjectTypeDefinition;
+import graphql.language.OperationDefinition;
+import graphql.language.SelectionSet;
 
 @ExtendWith(MockitoExtension.class)
 class GqlWriterTest {
 
+	private final ObjectTypeTranslator objectTypeTranslator = new ObjectTypeTranslator();
+	private final OperationTranslator operationTranslator = new OperationTranslator();
 	@Mock
 	private Document doc;
-
 	@Mock
 	private Log log;
-
 	@Mock
 	private WriterFactory writerFactory;
-
-	private final ObjectTypeTranslator translator = new ObjectTypeTranslator();
 	private GqlContext ctx;
 	private GqlConfiguration gqlConfiguration;
 	private StringWriter testWriter;
@@ -64,6 +65,18 @@ class GqlWriterTest {
 		then_the_generated_class_overrides_the_toString_method();
 		then_the_generated_class_overrides_the_equals_method();
 		then_the_generated_class_overrides_the_hashCode_method();
+	}
+
+	@Test
+	void translateOneQueryOperationTypeWithOneField() throws MojoExecutionException, IOException {
+		given_a_context_containing_query_operation_definition_with_one_field();
+		given_generate_defined_operations_config();
+		when_the_write_is_invoked();
+		assertThat(testWriter.toString()).containsIgnoringWhitespaces("\t@Override\n"
+				+ "\tpublic boolean equals(Object o) {\n"
+				+ "\t\tif (this == o) return true;\n"
+				+ "\t\tif (!(o instanceof GetInstrumentsQuery)) return false;\n"
+				+ "\t\tGetInstrumentsQuery other = (GetInstrumentsQuery) o;");
 	}
 
 	@Test
@@ -105,7 +118,7 @@ class GqlWriterTest {
 								.build())
 						.build()));
 		this.ctx = new GqlContext(log, emptyMap(), emptyMap());
-		translator.translate(doc, ctx);
+		objectTypeTranslator.translate(doc, ctx);
 	}
 
 	private void given_a_context_containing_an_object_without_fields() {
@@ -114,13 +127,36 @@ class GqlWriterTest {
 						.name("Object1")
 						.build()));
 		this.ctx = new GqlContext(log, emptyMap(), emptyMap());
-		translator.translate(doc, ctx);
+		objectTypeTranslator.translate(doc, ctx);
+	}
+
+	private void given_a_context_containing_query_operation_definition_with_one_field() {
+		when(doc.getDefinitionsOfType(OperationDefinition.class)).thenReturn(singletonList(
+				OperationDefinition.newOperationDefinition()
+						.name("GetInstruments")
+						.operation(OperationDefinition.Operation.QUERY)
+						.selectionSet(SelectionSet.newSelectionSet()
+								.selection(Field.newField("isin").build())
+								.build())
+						.build()));
+		this.ctx = new GqlContext(log, emptyMap(), emptyMap());
+		ctx.getOperations().put("query", "Query");
+		operationTranslator.translate(doc, ctx);
 	}
 
 	private void given_the_minimum_set_of_configurations() {
 		gqlConfiguration = GqlConfiguration.builder()
 				.schemaTypesPackageName("com.company.test")
 				.generateSchemaOtherTypes(true)
+				.build();
+	}
+
+	private void given_generate_defined_operations_config() {
+		gqlConfiguration = GqlConfiguration.builder()
+				.schemaTypesPackageName("com.company.test")
+				.generateSchemaOtherTypes(true)
+				.generateDefinedOperations(true)
+				.operationsPackageName("com.company.test")
 				.build();
 	}
 


### PR DESCRIPTION
Hi!
Currently its not convenient to write tests that involve generated implementations of operations (e.g. Query), because equals method is not generated.
``` java
@SuppressWarnings({"all", "PMD"})
public class GetInstrumentsQuery implements com.company.test.Query
{
	private static final String OPERATION_NAME = "GetInstruments";
	private static final String DOCUMENT = "\nquery GetInstruments {\n\tisin\n}\n";

	@Override
	public String getOperationName() {
		return OPERATION_NAME;
	}

	@Override
	public String getDocument() {
		return DOCUMENT;
	}

	@Override
	public java.util.Map<String, Object> getVariables() {
		return java.util.Collections.emptyMap();
	}

	@Override
	public Class<null.getInstrumentsQuery.results.QueryResult> getResultClass() {
		return null.getInstrumentsQuery.results.QueryResult.class;
	}

	@Override
	public String toString() {
		return new StringBuilder().append("{")
			.append(" operationName = ").append(getOperationName()).append(",")
			.append(" document = ").append(getDocument()).append(",")
			.append(" variables = ").append(getVariables())
			.append(" }")
			.toString();
	}
}
```
If I need to test that correct query is passed to function
``` java
public void requestInstruments(GetInstrumentsQuery query) {
 ...
} 
```
I have to do something like this:
``` java
verify(instrumentsRequester).requestInstruments(assertArg(v -> assertThat(v.getVariables()).containsEntry("isin", "US0378331005")));
```
Which is not convenient. 

I prefer this approach:
``` java
verify(instrumentsRequester).requestInstruments(new GetProfileAssignmentsQuery(vars -> vars.setIsin("US0378331005")));
```

It might also be useful if someone needs to use query object as key in Hash table (for instance to cache query result).
